### PR TITLE
Release: gatekeeper v2.2.2

### DIFF
--- a/.github/workflows/holo.yml
+++ b/.github/workflows/holo.yml
@@ -19,12 +19,3 @@ jobs:
         ref: releases/v2
         holobranch: emergence-skeleton
         commit-to: emergence/skeleton/v2
-    - name: 'Update holobranch: emergence/vfs-site/v2'
-      uses: JarvusInnovations/hologit@actions/projector/v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HAB_LICENSE: accept
-      with:
-        ref: releases/v2
-        holobranch: emergence-vfs-site
-        commit-to: emergence/vfs-site/v2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,15 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"bmewburn.vscode-intelephense-client",
-		"imperez.smarty"
-	]
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "bmewburn.vscode-intelephense-client",
+        "imperez.smarty",
+        "felixfbecker.php-debug",
+        "mtxr.sqltools"
+    ],
+    "unwantedRecommendations": [
+        "ms-mssql.mssql"
+    ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 7089,
+            "pathMappings": {
+                "/hab/svc/php-runtime/var/site/php-classes/Emergence": "${workspaceFolder:emergence-skeleton-v1}/php-classes/Emergence",
+                "/hab/svc/php-runtime/var/site": "${workspaceFolder:gatekeeper}",
+                "/src/emergence-php-core": "${workspaceFolder:emergence-php-core}"
+            },
+            "ignore": [
+                "**/vendor/**/*"
+            ]
+        }
+    ]
+}

--- a/html-templates/endpoints/endpointEdit.tpl
+++ b/html-templates/endpoints/endpointEdit.tpl
@@ -37,7 +37,7 @@
             <h4>Routing</h4>
 
             {capture assign=pathInputHtml}{strip}
-                http://{tif Gatekeeper\Gatekeeper::$apiHostname ? Gatekeeper\Gatekeeper::$apiHostname : "$.server.HTTP_HOST/api"}/&thinsp;
+                {Gatekeeper\Gatekeeper::getApiBaseUrl()}/&thinsp;
                 <input type="text" size=20 name="Path" required value="{refill field=Path default=$Endpoint->Path}" placeholder="transitview/v1">
             {/strip}{/capture}
             {labeledField html=$pathInputHtml type=compound label='Public Path' error=$errors.Path required=true}

--- a/php-classes/Gatekeeper/Endpoints/Endpoint.php
+++ b/php-classes/Gatekeeper/Endpoints/Endpoint.php
@@ -375,13 +375,7 @@ class Endpoint extends ActiveRecord
 
     public function getExternalUrl()
     {
-        $url = 'http://';
-
-        if (Gatekeeper::$apiHostname) {
-            $url .= Gatekeeper::$apiHostname;
-        } else {
-            $url .= Site::getConfig('primary_hostname') . '/api';
-        }
+        $url = Gatekeeper::getApiBaseUrl();
 
         $url .= '/' . $this->Path;
 

--- a/php-classes/Gatekeeper/Endpoints/Pinger.php
+++ b/php-classes/Gatekeeper/Endpoints/Pinger.php
@@ -38,6 +38,7 @@ class Pinger
         $response = HttpProxy::relayRequest([
             'autoAppend' => false,
             'autoQuery' => false,
+            'method' => 'GET',
             'url' => rtrim($Endpoint->InternalEndpoint, '/') . '/' . ltrim($Endpoint->PingURI, '/'),
             'interface' => ApiRequestHandler::$sourceInterface,
             'timeout' => 15,

--- a/php-classes/Gatekeeper/Endpoints/Pinger.php
+++ b/php-classes/Gatekeeper/Endpoints/Pinger.php
@@ -2,6 +2,7 @@
 
 namespace Gatekeeper\Endpoints;
 
+use Site;
 use Cache;
 use HttpProxy;
 
@@ -43,7 +44,13 @@ class Pinger
             'interface' => ApiRequestHandler::$sourceInterface,
             'timeout' => 15,
             'timeoutConnect' => 5,
-            'returnResponse' => true
+            'returnResponse' => true,
+            'forwardHeaders' => [],
+            'headers' => [
+                'Accept: */*',
+                'Accept-Language: *',
+                'User-Agent: ' . (ApiRequestHandler::$poweredByHeader ?: Site::$title)
+            ]
         ]);
 
 

--- a/php-classes/Gatekeeper/Endpoints/Pinger.php
+++ b/php-classes/Gatekeeper/Endpoints/Pinger.php
@@ -21,7 +21,7 @@ class Pinger
 
             if (
                 $lastPing === false
-                || $Endpoint->PingFrequency < time()-$lastPing['time'] // * 60
+                || $Endpoint->PingFrequency*60 < time()-$lastPing['time']
             ) {
                 static::pingEndpoint($Endpoint, $verbose);
             }
@@ -107,7 +107,7 @@ class Pinger
         Cache::store("endpoints/{$Endpoint->ID}/last-ping", [
             'time' => time(),
             'testPassed' => $testPassed
-        ], ($Endpoint->PingFrequency+5)); // * 60
+        ], ($Endpoint->PingFrequency+5)*60);
 
         return $testPassed;
     }

--- a/php-classes/Gatekeeper/Gatekeeper.php
+++ b/php-classes/Gatekeeper/Gatekeeper.php
@@ -2,6 +2,7 @@
 
 namespace Gatekeeper;
 
+use Site;
 use JSON;
 
 class Gatekeeper
@@ -9,6 +10,23 @@ class Gatekeeper
     public static $apiHostname;
     public static $portalHostname;
     public static $authRealm = 'Gatekeeper';
+
+    public static function getApiBaseUrl()
+    {
+        $url = Site::getConfig('ssl') ? 'https://' : 'http://';
+
+        if (static::$apiHostname) {
+            $url .= is_array(static::$apiHostname) ? static::$apiHostname[0] : static::$apiHostname;
+        } elseif (!empty($_SERVER['HTTP_HOST'])) {
+            $url .= $_SERVER['HTTP_HOST'];
+            $url .= '/api';
+        } else {
+            $url .= Site::getConfig('primary_hostname') ?: 'localhost';
+            $url .= '/api';
+        }
+
+        return $url;
+    }
 
     public static function authorizeTestApiAccess()
     {

--- a/site-root/health/endpoint-tests.php
+++ b/site-root/health/endpoint-tests.php
@@ -83,7 +83,7 @@ Site::$production = false;
             <td><?=$Endpoint->Path?></td>
             <td><?=$Endpoint->PingURI?></td>
             <td><?=$Endpoint->PingTestPattern?></td>
-            <td><?=($url || '')?></td>
+            <td><?=($url ?: '')?></td>
             <td><?=($response ? $response['info']['http_code'] : '')?></td>
             <td><?=($response ? (strlen($response['body']) . ' bytes') : '')?></td>
             <td><?=($testPassed === null ? '' : ($testPassed ? 'Y' : 'N'))?></td>

--- a/site-root/health/endpoint-tests.php
+++ b/site-root/health/endpoint-tests.php
@@ -56,7 +56,13 @@ Site::$production = false;
                 'interface' => ApiRequestHandler::$sourceInterface,
                 'timeout' => 15,
                 'timeoutConnect' => 5,
-                'returnResponse' => true
+                'returnResponse' => true,
+                'forwardHeaders' => [],
+                'headers' => [
+                    'Accept: */*',
+                    'Accept-Language: *',
+                    'User-Agent: ' . (ApiRequestHandler::$poweredByHeader ?: Site::$title)
+                ]
             ]);
 
             // evaluate success


### PR DESCRIPTION
- fix: remove GitHub Actions workflow step for vfs-site holobranch
- fix: centralize getApiBaseUrl logic and handle array-values for $apiHostname correctly
- fix: evaluate ping frequency in minutes
- fix: force GET method for ping tests
- fix: force normalized headers for ping tests
- fix: display complete request URL in endpoint-tests report
- chore: add xdebug and sqltools to recommended vscode extensions
- chore: add vscode debug launcher config