### PR TITLE
Release: gatekeeper v2.2.4

### DIFF
--- a/.holo/sources/skeleton-v2.toml
+++ b/.holo/sources/skeleton-v2.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/emergence-skeleton-v2"
-ref = "refs/heads/releases/v2"
+ref = "refs/tags/v2.4.0"
 
 [holosource.project]
 holobranch = "emergence-skeleton"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Listen for XDebug",
             "type": "php",
             "request": "launch",
-            "port": 7089,
+            "port": 9000,
             "pathMappings": {
                 "/hab/svc/php-runtime/var/site/php-classes/Emergence": "${workspaceFolder:emergence-skeleton-v1}/php-classes/Emergence",
                 "/hab/svc/php-runtime/var/site": "${workspaceFolder:gatekeeper}",

--- a/php-config/Site.config.d/gatekeeper-sessions.php
+++ b/php-config/Site.config.d/gatekeeper-sessions.php
@@ -1,5 +1,5 @@
 <?php
 
-Site::$skipSessionPaths[] = 'api.php';
-Site::$skipSessionPaths[] = 'test-api/cachable.php';
-Site::$skipSessionPaths[] = 'test-api/status.php';
+Site::$skipSessionPaths[] = 'api/';
+Site::$skipSessionPaths[] = 'test-api/';
+Site::$skipSessionPaths[] = 'local-api/';


### PR DESCRIPTION
- fix: use path prefix for Site::$skipSessionPaths
- fix: use default xdebug port
- chore: bump skeleton-v2 version to v2.4.0