### PR TITLE
Release: gatekeeper v2.2.5

### DIFF
--- a/php-classes/Gatekeeper/Endpoints/Endpoint.php
+++ b/php-classes/Gatekeeper/Endpoints/Endpoint.php
@@ -245,6 +245,10 @@ class Endpoint extends ActiveRecord
             return;
         }
 
+        if (!$Endpoint->isFieldDirty('Path')) {
+            return;
+        }
+
         $duplicateConditions = [
             'Path' => $Endpoint->Path
         ];

--- a/php-classes/Gatekeeper/Endpoints/Endpoint.php
+++ b/php-classes/Gatekeeper/Endpoints/Endpoint.php
@@ -353,7 +353,7 @@ class Endpoint extends ActiveRecord
         $cacheKey = "endpoints/$this->ID/rewrites";
 
         // get ordered list of rewrites
-        if (false == ($rewriteIDs = Cache::fetch($cacheKey))) {
+        if (false === ($rewriteIDs = Cache::fetch($cacheKey))) {
             $rewriteIDs = array_map(function($Rewrite) {
                 return $Rewrite->ID;
             }, $this->Rewrites);


### PR DESCRIPTION
- fix: skip validation of non-dirty path
- fix: use strict equality to test rewrite cache hit