### PR TITLE
feat: enable tracking history for endpoints records

### DIFF
--- a/php-classes/Gatekeeper/Endpoints/Endpoint.php
+++ b/php-classes/Gatekeeper/Endpoints/Endpoint.php
@@ -4,7 +4,6 @@ namespace Gatekeeper\Endpoints;
 
 use Site;
 use Cache;
-use ActiveRecord;
 use HandleBehavior;
 use RecordValidator;
 use TableNotFoundException;
@@ -14,7 +13,7 @@ use Gatekeeper\Metrics\Metrics;
 use Gatekeeper\Alerts\AbstractAlert;
 use Symfony\Component\Yaml\Yaml;
 
-class Endpoint extends ActiveRecord
+class Endpoint extends \VersionedRecord
 {
     public static $metricTTL = 60;
     public static $validPathRegex = '/^[a-zA-Z][a-zA-Z0-9_\\-\\.]*(\\/[a-zA-Z][a-zA-Z0-9_\\-\\.]*)*$/';

--- a/php-migrations/Gatekeeper/Endpoint/20210103_endpoint-history.php
+++ b/php-migrations/Gatekeeper/Endpoint/20210103_endpoint-history.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Gatekeeper\Endpoints;
+
+
+use DB;
+use SQL;
+
+
+$tableName = Endpoint::$tableName;
+$historyTableName = Endpoint::getHistoryTableName();
+$skipped = true;
+
+
+// skip if primary table does not exist or history table already exists
+if (!static::tableExists(Endpoint::$tableName)) {
+    printf("Skipping migration because table `%s` does not yet exist\n", Endpoint::$tableName);
+    return static::STATUS_SKIPPED;
+}
+
+
+// create history table if needed
+if (!static::tableExists($historyTableName)) {
+    printf("Creating history table `%s`\n", $historyTableName);
+    DB::multiQuery(SQL::getCreateTable(Endpoint::class));
+    $skipped = false;
+}
+
+
+// add modified/modifier columns
+if (!static::columnExists($tableName, 'Modified')) {
+    printf("Adding `Modified` column to `%s` table\n", $tableName);
+    DB::nonQuery('ALTER TABLE `%s` ADD `Modified` timestamp NULL default NULL AFTER `CreatorID`', $tableName);
+    $skipped = false;
+}
+
+if (!static::columnExists($tableName, 'ModifierID')) {
+    printf("Adding `ModifierID` column to `%s` table\n", $tableName);
+    DB::nonQuery('ALTER TABLE `%s` ADD `ModifierID` int unsigned NULL default NULL AFTER `Modified`', $tableName);
+    $skipped = false;
+}
+
+
+// finish
+return $skipped ? static::STATUS_SKIPPED : static::STATUS_EXECUTED;


### PR DESCRIPTION
## Why

Old versions of endpoint configurations were not stored in a history table

## What

Enable versioning endpoint data and backfill history table